### PR TITLE
add granularity to timer percentiles

### DIFF
--- a/statsd-config-wf.js
+++ b/statsd-config-wf.js
@@ -10,5 +10,6 @@
     graphite: {
         globalPrefix: "stats",
         legacyNamespace: false
-    }
+    },
+    percentThreshold: [50, 90, 95, 99]
 }


### PR DESCRIPTION
Add granularity: p50, p95, p99; Leave 90 in for backwards compatibility with metrics
This field if not specified defaults to `90`.

[example config](https://github.com/doordash/etsy-statsd/blob/master/exampleConfig.js)
[metric types reference](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#timing)

@doordash/pe 